### PR TITLE
简单优化了一下

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+target = "i686-pc-windows-msvc"
+
+[target.i686-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "betterncm_installer"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -15,15 +15,19 @@ druid = { git = "https://github.com/linebender/druid.git", features = [
     "serde",
     "raw-win-handle",
 ] }
-futures = "0.3"
-reqwest = { version = "*", features = ["stream"] }
-tokio = { version = "*", features = ["full"] }
 scl-gui-widgets = { path = "./scl-gui-widgets" }
 serde_json = "1.0.79"
-futures-util = "0.3.14"
 winreg = "0.10.1"
 anyhow = "*"
 pelite = "0.10.0"
-winapi = "*"
 semver = "1.0.16"
 dirs = "*"
+tinyget = { version = "1.0", features = ["https"] }
+
+[profile.release]
+lto = true
+codegen-units = 1
+panic = "abort"
+opt-level = "z"
+debug = false
+strip = true

--- a/README.md
+++ b/README.md
@@ -16,3 +16,8 @@
 
 # 插件库
 已在 BetterNCM 内置
+
+# 构建
+```bash
+cargo +nightly build --release -Z build-std=core,alloc,std,panic_abort -Z build-std-features=panic_immediate_abort --target i686-pc-windows-msvc
+```

--- a/src/ncm_utils.rs
+++ b/src/ncm_utils.rs
@@ -24,6 +24,12 @@ pub fn get_ncm_install_path() -> Result<PathBuf> {
     }
 }
 
+pub fn is_vc_redist_14_x86_installed() -> bool {
+    let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
+    hklm.open_subkey("SOFTWARE\\WOW6432Node\\Microsoft\\VisualStudio\\14.0\\VC\\Runtimes\\X86")
+        .is_ok()
+}
+
 pub fn get_ncm_version() -> Result<Version> {
     let map = FileMap::open(&get_ncm_install_path()?.join("cloudmusic.exe"))?;
     let file = PeFile::from_bytes(&map)?;


### PR DESCRIPTION
丢掉 tokio，直接多线程
默认使用 i686 构建
使用 tinyget 来网络请求
通过奇妙的压缩方式压榨了产物体积并静态链接编译，用户不需要安装运行时就可以启动安装器了。
会检查 VC 运行时的安装情况并自动安装 VCRedist 14 了。

有以下需要注意的：
- 构建产物路径变为了 `target/i686-pc-windows-msvc/release/betterncm_installer.exe`
- 可以直接使用 `stable` 频道的编译器编译安装器，同时可以使用 `cargo +nightly build --release -Z build-std=core,alloc,std,panic_abort -Z build-std-features=panic_immediate_abort --target i686-pc-windows-msvc` 来最大限度优化体积。

安装器体积从 1.0.2 的 5091 KB 下降到了 679 KB
![image](https://user-images.githubusercontent.com/39523898/218278226-ca5a74bc-eca9-4b6c-9966-f9ec92a2e61e.png)
~~比 BetterNCM.dll 还小~~

